### PR TITLE
Disable withCredentials request

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -271,7 +271,8 @@ API.prototype._doRequest = function(method, url, args, cb) {
     method: method,
     url: absUrl,
     body: args,
-    json: true
+    json: true,
+    withCredentials: false
   };
 
   log.debug('Request Args', util.inspect(args, {


### PR DESCRIPTION
As we do not use cookies, this is not necessary.