### PR TITLE
return wallet status on openwallet

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -422,7 +422,7 @@ API.prototype.openWallet = function(cb) {
     var wallet = ret.wallet;
 
     if (wallet.status != 'complete')
-      return cb(null, false);
+      return cb();
 
     if (self.credentials.walletPrivKey) {
 
@@ -461,7 +461,7 @@ API.prototype.openWallet = function(cb) {
       self.emit('walletCompleted', wallet);
     }
 
-    return cb(null, true);
+    return cb(null, ret);
   });
 };
 

--- a/test/client.js
+++ b/test/client.js
@@ -280,9 +280,9 @@ describe('client API', function() {
         should.not.exist(err);
         clients[1].joinWallet(secret, 'guest', function(err) {
           should.not.exist(err);
-          clients[0].openWallet(function(err, isComplete) {
+          clients[0].openWallet(function(err, walletStatus) {
             should.not.exist(err);
-            isComplete.should.be.true;
+            should.exist(walletStatus);
             if (++checks == 2) done();
           });
         });


### PR DESCRIPTION
returns walletSTatus on openWallet to allow clients to avoid calling getSTatus again.