### PR TITLE
Feat/import legacy3

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -1044,41 +1044,52 @@ API.prototype.createWalletFromOldCopay = function(username, password, blob, cb) 
   var pubKey = hd.publicKey.toString('hex');
   var copayerName = w.publicKeyRing.nicknameFor[pubKey] || username;
 
+  // First: Try to get the wallet with the imported credentials...
+  this.getStatus(function(err) {
 
-  this.createWallet(walletName, copayerName, m, n, {
-    network: network,
-    id: walletId,
-    walletPrivKey: walletPrivKey,
-  }, function(err, secret) {
-
-    if (err && err.code == 'WEXISTS') {
-
+    // No error? -> Wallet is ready.
+    if (!err) {
+      log.debug('Wallet is already imported');
       self.credentials.addWalletInfo(walletId, walletName, m, n,
         walletPrivKey, copayerName);
+      return cb();
+    };
 
-      return self._replaceTemporaryRequestKey(function(err) {
-        if (err) return cb(err);
-        self.openWallet(function(err) {
-          return cb(err, true);
+    self.createWallet(walletName, copayerName, m, n, {
+      network: network,
+      id: walletId,
+      walletPrivKey: walletPrivKey,
+    }, function(err, secret) {
+
+      if (err && err.code == 'WEXISTS') {
+
+        self.credentials.addWalletInfo(walletId, walletName, m, n,
+          walletPrivKey, copayerName);
+
+        return self._replaceTemporaryRequestKey(function(err) {
+          if (err) return cb(err);
+          self.openWallet(function(err) {
+            return cb(err, true);
+          });
         });
-      });
-    }
-    if (err) return cb(err);
+      }
+      if (err) return cb(err);
 
-    var i = 1;
-    async.eachSeries(self.credentials.publicKeyRing, function(item, next) {
-      if (item.xPubKey == self.credentials.xPubKey)
-        return next();
+      var i = 1;
+      async.eachSeries(self.credentials.publicKeyRing, function(item, next) {
+        if (item.xPubKey == self.credentials.xPubKey)
+          return next();
 
-      var copayerName;
-      // Grab Copayer Name
-      var hd = new Bitcore.HDPublicKey(item.xPubKey).derive('m/2147483646/0/0');
-      var pubKey = hd.publicKey.toString('hex');
-      copayerName = w.publicKeyRing.nicknameFor[pubKey] || 'recovered copayer #' + i++;
-      self._doJoinWallet(walletId, walletPrivKey, item.xPubKey, item.requestPubKey, copayerName, {
-        isTemporaryRequestKey: true
-      }, next);
-    }, cb);
+        var copayerName;
+        // Grab Copayer Name
+        var hd = new Bitcore.HDPublicKey(item.xPubKey).derive('m/2147483646/0/0');
+        var pubKey = hd.publicKey.toString('hex');
+        copayerName = w.publicKeyRing.nicknameFor[pubKey] || 'recovered copayer #' + i++;
+        self._doJoinWallet(walletId, walletPrivKey, item.xPubKey, item.requestPubKey, copayerName, {
+          isTemporaryRequestKey: true
+        }, next);
+      }, cb);
+    });
   });
 };
 

--- a/lib/api.js
+++ b/lib/api.js
@@ -432,6 +432,7 @@ API.prototype.openWallet = function(cb) {
     if (err) return cb(err);
     var wallet = ret.wallet;
 
+console.log('[api.js.434] HOLa'); //TODO
     if (wallet.status != 'complete')
       return cb();
 

--- a/lib/api.js
+++ b/lib/api.js
@@ -140,6 +140,8 @@ API._processTxps = function(txps, encryptingKey) {
     txp.message = API._decryptMessage(txp.message, encryptingKey);
     _.each(txp.actions, function(action) {
       action.comment = API._decryptMessage(action.comment, encryptingKey);
+      // TODO get copayerName from Credentials -> copayerId to copayerName
+      // action.copayerName = null;
     });
   });
 };
@@ -573,6 +575,7 @@ API.prototype.recreateWallet = function(cb) {
     n: self.credentials.n,
     pubKey: walletPrivKey.toPublicKey().toString(),
     network: self.credentials.network,
+    id: self.credentials.walletId,
   };
   self._doPostRequest('/v1/wallets/', args, function(err, body) {
     if (err) return cb(err);
@@ -805,6 +808,7 @@ API.prototype.signTxProposal = function(txp, cb) {
 
     self._doPostRequest(url, args, function(err, txp) {
       if (err) return cb(err);
+      API._processTxps([txp], self.credentials.sharedEncryptingKey);
       return cb(null, txp);
     });
   })
@@ -870,6 +874,7 @@ API.prototype.rejectTxProposal = function(txp, reason, cb) {
   };
   self._doPostRequest(url, args, function(err, txp) {
     if (err) return cb(err);
+    API._processTxps([txp], self.credentials.sharedEncryptingKey);
     return cb(null, txp);
   });
 };
@@ -1042,7 +1047,6 @@ API.prototype.createWalletFromOldCopay = function(username, password, blob, cb) 
 
   // First: Try to get the wallet with the imported credentials...
   this.getStatus(function(err) {
-
     // No error? -> Wallet is ready.
     if (!err) {
       log.debug('Wallet is already imported');

--- a/lib/api.js
+++ b/lib/api.js
@@ -276,9 +276,10 @@ API.prototype._doRequest = function(method, url, args, cb) {
 
   var reqSignature;
 
-  if (this.credentials.requestPrivKey) {
+  if (this.credentials.requestPrivKey || args._requestPrivKey) {
     reqSignature = API._signRequest(method, url, args, args._requestPrivKey || this.credentials.requestPrivKey);
   }
+
   var absUrl = this.baseUrl + url;
   var args = {
     // relUrl: only for testing with `supertest`
@@ -515,7 +516,6 @@ API.prototype.createWallet = function(walletName, copayerName, m, n, opts, cb) {
     if (err) return cb(err);
 
     var walletId = body.walletId;
-
     var secret = WalletUtils.toSecret(walletId, walletPrivKey, network);
     self.credentials.addWalletInfo(walletId, walletName, m, n, walletPrivKey.toString(), copayerName);
 
@@ -581,7 +581,9 @@ API.prototype.recreateWallet = function(cb) {
 
     var i = 1;
     async.each(self.credentials.publicKeyRing, function(item, next) {
-      self._doJoinWallet(walletId, walletPrivKey, item.xPubKey, item.requestPubKey, item.copayerName, {}, next);
+      self._doJoinWallet(walletId, walletPrivKey, item.xPubKey, item.requestPubKey, item.copayerName, {
+        isTemporaryRequestKey: item.isTemporaryRequestKey,
+      }, next);
     }, cb);
   });
 };
@@ -1035,14 +1037,8 @@ API.prototype.createWalletFromOldCopay = function(username, password, blob, cb) 
   var walletName = w.opts.name;
   var network = w.opts.networkName;
   this.credentials = Credentials.fromOldCopayWallet(w);
-
   var walletPrivKey = this._walletPrivKeyFromOldCopayWallet(w);
-
-
-  // Grab My Copayer Name
-  var hd = new Bitcore.HDPublicKey(self.credentials.xPubKey).derive('m/2147483646/0/0');
-  var pubKey = hd.publicKey.toString('hex');
-  var copayerName = w.publicKeyRing.nicknameFor[pubKey] || username;
+  var copayerName = this.credentials.copayerName;
 
   // First: Try to get the wallet with the imported credentials...
   this.getStatus(function(err) {
@@ -1060,7 +1056,6 @@ API.prototype.createWalletFromOldCopay = function(username, password, blob, cb) 
       id: walletId,
       walletPrivKey: walletPrivKey,
     }, function(err, secret) {
-
       if (err && err.code == 'WEXISTS') {
 
         self.credentials.addWalletInfo(walletId, walletName, m, n,
@@ -1079,13 +1074,7 @@ API.prototype.createWalletFromOldCopay = function(username, password, blob, cb) 
       async.eachSeries(self.credentials.publicKeyRing, function(item, next) {
         if (item.xPubKey == self.credentials.xPubKey)
           return next();
-
-        var copayerName;
-        // Grab Copayer Name
-        var hd = new Bitcore.HDPublicKey(item.xPubKey).derive('m/2147483646/0/0');
-        var pubKey = hd.publicKey.toString('hex');
-        copayerName = w.publicKeyRing.nicknameFor[pubKey] || 'recovered copayer #' + i++;
-        self._doJoinWallet(walletId, walletPrivKey, item.xPubKey, item.requestPubKey, copayerName, {
+        self._doJoinWallet(walletId, walletPrivKey, item.xPubKey, item.requestPubKey, item.copayerName, {
           isTemporaryRequestKey: true
         }, next);
       }, cb);

--- a/lib/credentials.js
+++ b/lib/credentials.js
@@ -116,7 +116,9 @@ Credentials.prototype.addWalletInfo = function(walletId, walletName, m, n, walle
   if (walletPrivKey)
     this.sharedEncryptingKey = WalletUtils.privateKeyToAESKey(walletPrivKey);
 
-  this.copayerName = copayerName;
+  if (copayerName)
+    this.copayerName = copayerName;
+
   if (n == 1) {
     this.addPublicKeyRing([{
       xPubKey: this.xPubKey,
@@ -226,14 +228,23 @@ Credentials.fromOldCopayWallet = function(w){
       var path = WalletUtils.PATHS.TMP_REQUEST_KEY;
       requestDerivation = (new Bitcore.HDPublicKey(xPubStr)).derive(path);
     }
+
+    // Grab Copayer Name
+    var hd = new Bitcore.HDPublicKey(xPubStr).derive('m/2147483646/0/0');
+    var pubKey = hd.publicKey.toString('hex');
+    var copayerName = w.publicKeyRing.nicknameFor[pubKey];
+    if (isMe) {
+      credentials.copayerName = copayerName;
+    }
+
     return {
       xPubKey: xPubStr,
       requestPubKey: requestDerivation.publicKey.toString(),
       isTemporaryRequestKey: !isMe,
+      copayerName: copayerName,
     };
   });
   credentials.addPublicKeyRing(pkr);
-
   return credentials;
 };
 

--- a/lib/verifier.js
+++ b/lib/verifier.js
@@ -89,7 +89,6 @@ Verifier.checkTxProposalBody = function(credentials, txp) {
 
   if (!creatorKeys) return false;
 
-  // TODO: this should be an independent key
   var creatorSigningPubKey = creatorKeys.requestPubKey;
   var hash = WalletUtils.getProposalHash(txp.toAddress, txp.amount, txp.encryptedMessage || txp.message, txp.payProUrl);
   log.debug('Regenerating & verifying tx proposal hash -> Hash: ', hash, ' Signature: ', txp.proposalSignature);

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "bitcore-wallet-client",
   "description": "Client for bitcore-wallet-service",
   "author": "BitPay Inc",
-  "version": "0.0.22",
+  "version": "0.0.23",
   "keywords": [
     "bitcoin",
     "copay",

--- a/test/client.js
+++ b/test/client.js
@@ -1617,7 +1617,29 @@ describe('client API', function() {
         });
       });
     });
-    it('Should fail to import the same wallet twice', function(done) {
+    it('Should to import the same wallet twice with different clients', function(done) {
+      var t = ImportData.copayers[0];
+      var c = helpers.newClient(app);
+      c.createWalletFromOldCopay(t.username, t.password, t.ls['wallet::4d32f0737a05f072'], function(err) {
+        should.not.exist(err);
+        c.getStatus(function(err, status) {
+          should.not.exist(err);
+          status.wallet.status.should.equal('complete');
+          c.credentials.walletId.should.equal('4d32f0737a05f072');
+          var c2 = helpers.newClient(app);
+          c2.createWalletFromOldCopay(t.username, t.password, t.ls['wallet::4d32f0737a05f072'], function(err) {
+            should.not.exist(err);
+            c2.getStatus(function(err, status) {
+              should.not.exist(err);
+              status.wallet.status.should.equal('complete');
+              c2.credentials.walletId.should.equal('4d32f0737a05f072');
+              done();
+            });
+          });
+        });
+      });
+    });
+    it('Should not fail when importing the same wallet twice, same copayer', function(done) {
       var t = ImportData.copayers[0];
       var c = helpers.newClient(app);
       c.createWalletFromOldCopay(t.username, t.password, t.ls['wallet::4d32f0737a05f072'], function(err) {
@@ -1627,14 +1649,13 @@ describe('client API', function() {
           status.wallet.status.should.equal('complete');
           c.credentials.walletId.should.equal('4d32f0737a05f072');
           c.createWalletFromOldCopay(t.username, t.password, t.ls['wallet::4d32f0737a05f072'], function(err) {
-            // this throws invalid signature because
-            // the it trys correctly to replace req pub key, but auth fails
-            err.message.should.contain('Invalid signature');
+            should.not.exist(err);
             done();
           });
         });
       });
     });
+
     it('Should import and complete 2-2 wallet from 2 copayers, and create addresses', function(done) {
       var t = ImportData.copayers[0];
       var c = helpers.newClient(app);


### PR DESCRIPTION
 - fix: set walletId on recreate
 - fix: keep isTemporaryRequestKey on recreate
 - process tx on reject and sign
 - use copayerName from credentials at `createFromOldCopay`

 - adds some TODOs and tests in order to use copayerNames from credentials and not from the server (at actions)