### PR TITLE
External xpubkey source support

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -227,6 +227,17 @@ API.prototype.seedFromExtendedPrivateKey = function(xPrivKey) {
   this.credentials = Credentials.fromExtendedPrivateKey(xPrivKey);
 };
 
+/**
+ * Seed from external wallet public key
+ *
+ * @param {String} xPubKey - Extended public key
+ * @param {String} source - name of external wallet source (ex: ledger)
+ * @params{Number} index - index of the external key
+ */
+API.prototype.seedFromExternalWalletPublicKey = function(xPubKey, source, index) {
+  this.credentials = Credentials.fromExternalWalletPublicKey(xPubKey, source, index);
+}
+
 
 /**
  * Export wallet
@@ -446,6 +457,33 @@ API.prototype.isPrivKeyEncrypted = function() {
  */
 API.prototype.hasPrivKeyEncrypted = function() {
   return this.credentials && this.credentials.hasPrivKeyEncrypted();
+};
+
+/**
+ * Is private key external?
+ *
+ * @return {Boolean}
+ */
+API.prototype.isPrivKeyExternal = function() {
+  return this.credentials && this.credentials.hasExternalSource();
+};
+
+/**
+ * Get external wallet source name
+ *
+ * @return {String}
+ */
+API.prototype.getPrivKeyExternalSourceName = function() {
+  return this.credentials ? this.credentials.getExternalSourceName() : null;
+};
+
+/**
+ * Get external wallet key index
+ *
+ * @return {Number}
+ */
+API.prototype.getExternalIndex = function() {
+  return this.credentials ? this.credentials.getExternalIndex() : null;
 };
 
 /**

--- a/lib/credentials.js
+++ b/lib/credentials.js
@@ -6,7 +6,7 @@ var WalletUtils = require('bitcore-wallet-utils');
 var Bitcore = WalletUtils.Bitcore;
 var sjcl = require('sjcl');
 
-var FIELDS = [
+var FIELDS = [  
   'network',
   'xPrivKey',
   'xPrivKeyEncrypted',
@@ -23,6 +23,8 @@ var FIELDS = [
   'personalEncryptingKey',
   'sharedEncryptingKey',
   'copayerName',
+  'externalSource',
+  'externalIndex'
 ];
 
 var EXPORTABLE_FIELDS = [
@@ -34,6 +36,8 @@ var EXPORTABLE_FIELDS = [
   'n',
   'publicKeyRing',
   'sharedEncryptingKey',
+  'externalSource',
+  'externalIndex'
 ];
 
 function Credentials() {
@@ -56,6 +60,15 @@ Credentials.fromExtendedPrivateKey = function(xPrivKey) {
   return x;
 };
 
+Credentials.fromExternalWalletPublicKey = function(xPubKey, source, index) {
+  var x = new Credentials();
+  x.xPubKey = xPubKey;
+  x.externalSource = source;
+  x.externalIndex = index;
+  x._expand();
+  return x;
+};
+
 Credentials.prototype._expand = function() {
   $.checkState(this.xPrivKey || this.xPubKey);
 
@@ -70,6 +83,12 @@ Credentials.prototype._expand = function() {
     this.requestPubKey = requestDerivation.publicKey.toString();
   }
   var network = WalletUtils.getNetworkFromXPubKey(this.xPubKey);
+  if (typeof this.externalSource == "string") {
+    var xPrivKey = new Bitcore.HDPrivateKey(network);
+    var requestDerivation = xPrivKey.derive(WalletUtils.PATHS.REQUEST_KEY);
+    this.requestPrivKey = requestDerivation.privateKey.toString();
+    this.requestPubKey = requestDerivation.publicKey.toString();    
+  }  
   if (this.network) {
     $.checkState(this.network == network);
   } else {
@@ -197,6 +216,18 @@ Credentials.prototype.isComplete = function() {
   if (!this.m || !this.n) return false;
   if (!this.publicKeyRing || this.publicKeyRing.length != this.n) return false;
   return true;
+};
+
+Credentials.prototype.hasExternalSource = function() {
+  return (typeof this.externalSource == "string");
+};
+
+Credentials.prototype.getExternalSourceName = function() {
+  return this.externalSource;
+};
+
+Credentials.prototype.getExternalIndex = function() {
+  return this.externalIndex;
 };
 
 Credentials.prototype.hasTemporaryRequestKeys = function() {

--- a/lib/credentials.js
+++ b/lib/credentials.js
@@ -83,11 +83,10 @@ Credentials.prototype._expand = function() {
     this.requestPubKey = requestDerivation.publicKey.toString();
   }
   var network = WalletUtils.getNetworkFromXPubKey(this.xPubKey);
-  if (typeof this.externalSource == "string") {
-    var xPrivKey = new Bitcore.HDPrivateKey(network);
-    var requestDerivation = xPrivKey.derive(WalletUtils.PATHS.REQUEST_KEY);
-    this.requestPrivKey = requestDerivation.privateKey.toString();
-    this.requestPubKey = requestDerivation.publicKey.toString();    
+  if (this.hasExternalSource()) {
+    var xPrivKey = new Bitcore.PrivateKey(network);
+    this.requestPrivKey = xPrivKey.toString();
+    this.requestPubKey = xPrivKey.toPublicKey().toString();
   }  
   if (this.network) {
     $.checkState(this.network == network);

--- a/test/client.js
+++ b/test/client.js
@@ -446,6 +446,14 @@ describe('client API', function() {
         });
       });
     });
+    it('should prepare wallet with external xpubkey', function(done) {
+      var client = helpers.newClient(app);
+      client.seedFromExternalWalletPublicKey('xpub6D52jcEfKA4cGeGcVC9pwG37Ju8pUMQrhptw82QVHRSAGBELE5uCee7Qq8RJUqQVyxfJfwbJKYyqyFhc2Xg8cJyN11kRvnAaWcACXP6K0zv', 'ledger', 2);
+      client.isPrivKeyExternal().should.equal(true);
+      client.getPrivKeyExternalSourceName().should.equal('ledger');
+      client.getExternalIndex().should.equal(2);
+      done();
+    });
   });
 
   describe('Preferences', function() {


### PR DESCRIPTION
Support external xpubkey source when creating or joining a wallet. Necessary for hardware wallet integration (such as Ledger)