### PR TITLE
Double check validation

### DIFF
--- a/lib/credentials.js
+++ b/lib/credentials.js
@@ -63,6 +63,9 @@ Credentials.createWithMnemonic = function(network, passphrase, language) {
     throw new Error('Unsupported language');
 
   var m = new Mnemonic(wordsForLang[language]);
+  while (!Mnemonic.isValid(m.toString())) {
+    m = new Mnemonic(wordsForLang[language])
+  };
   var x = new Credentials();
 
   x.network = network;


### PR DESCRIPTION
bitcore-mnemonic can not verify phrases with isValid in the (very rare) circumstances that: 
1. it is a mnemonic made with words common between 2 different wordlists
2. the checksum only matches for the wordlist which is a higher index on the list of wordlists within bitcore-mnemonic.

A mnemonic meeting those two rare cases will, when the language is unspecified, check all the words in each wordlist in order to find the wordlist. Since the first match is the wordlist used, and the checksum only matches the higher (later) indexed wordlist, it will be generated as a valid phrase but when checked, will be invalid (because we don't pass the language when checking the phrase in Copay)

A more long-term solution would be to change Copay to check the current locale's wordlist first when checking. (Without limiting ie. a French person from using a Japanese phrase or something)

However, this is a 1 in 100 quadrillion chance with English and French, so this simple fix might be fine for now.