### PR TITLE
normalize to null payproURL

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -1287,7 +1287,7 @@ API.prototype.sendTxProposal = function(opts, cb) {
     amount: opts.amount,
     message: API._encryptMessage(opts.message, this.credentials.sharedEncryptingKey) || null,
     feePerKb: opts.feePerKb,
-    payProUrl: opts.payProUrl,
+    payProUrl: opts.payProUrl || null,
     excludeUnconfirmedUtxos: !!opts.excludeUnconfirmedUtxos,
     type: opts.type,
     outputs: _.cloneDeep(opts.outputs),

--- a/lib/api.js
+++ b/lib/api.js
@@ -1208,12 +1208,12 @@ API.prototype._computeProposalSignature = function(args) {
         return _.pick(output, ['toAddress', 'amount', 'message']);
       }),
       message: args.message || null,
-      payProUrl: args.payProUrl
+      payProUrl: args.payProUrl || null,
     };
     hash = WalletUtils.getProposalHash(proposalHeader);
   } else {
     $.shouldBeNumber(args.amount);
-    hash = WalletUtils.getProposalHash(args.toAddress, args.amount, args.message || null, args.payProUrl);
+    hash = WalletUtils.getProposalHash(args.toAddress, args.amount, args.message || null, args.payProUrl || null);
   }
   return WalletUtils.signMessage(hash, this.credentials.requestPrivKey);
 }

--- a/lib/verifier.js
+++ b/lib/verifier.js
@@ -115,11 +115,11 @@ Verifier.checkTxProposalBody = function(credentials, txp) {
     var proposalHeader = {
       outputs: outputs,
       message: txp.encryptedMessage || txp.message || null,
-      payProUrl: txp.payProUrl
+      payProUrl: txp.payProUrl || null,
     };
     hash = WalletUtils.getProposalHash(proposalHeader);
   } else {
-    hash = WalletUtils.getProposalHash(txp.toAddress, txp.amount, txp.encryptedMessage || txp.message || null, txp.payProUrl);
+    hash = WalletUtils.getProposalHash(txp.toAddress, txp.amount, txp.encryptedMessage || txp.message || null, txp.payProUr || null);
   }
   log.debug('Regenerating & verifying tx proposal hash -> Hash: ', hash, ' Signature: ', txp.proposalSignature);
 

--- a/lib/verifier.js
+++ b/lib/verifier.js
@@ -119,7 +119,7 @@ Verifier.checkTxProposalBody = function(credentials, txp) {
     };
     hash = WalletUtils.getProposalHash(proposalHeader);
   } else {
-    hash = WalletUtils.getProposalHash(txp.toAddress, txp.amount, txp.encryptedMessage || txp.message || null, txp.payProUr || null);
+    hash = WalletUtils.getProposalHash(txp.toAddress, txp.amount, txp.encryptedMessage || txp.message || null, txp.payProUrl || null);
   }
   log.debug('Regenerating & verifying tx proposal hash -> Hash: ', hash, ' Signature: ', txp.proposalSignature);
 


### PR DESCRIPTION
fixes proposal signature in case client deliver `undefined` as value.

See https://github.com/bitpay/bitcore-wallet-client/pull/98/files