### PR TITLE
Allow both toAddress and script for same output

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -800,7 +800,7 @@ API.buildTx = function(txp) {
     t.to(txp.toAddress, txp.amount);
   } else if (txp.outputs) {
     _.each(txp.outputs, function(o) {
-      $.checkState(!o.script != !o.toAddress, 'Output should have either toAddress or script specified');
+      $.checkState(o.script || o.toAddress, 'Output should have either toAddress or script specified');
       if (o.script) {
         t.addOutput(new Bitcore.Transaction.Output({
           script: o.script,


### PR DESCRIPTION
Spin-off from this discussion: https://github.com/bitpay/bitcore-wallet-utils/pull/27#discussion-diff-36525967

If both toAddress and script specified, the latter will be actually used in output. Address will be used for display/info purposes (e.g. in Copay to display recipient).

Duplicates https://github.com/bitpay/bitcore-wallet-utils/pull/34