### PR TITLE
Fix buildTx for MULTIPLEOUTPUTS proposal without change

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -823,10 +823,9 @@ API.buildTx = function(txp) {
 
   // Shuffle outputs for improved privacy
   if (t.outputs.length > 1) {
-    var outputOrder = txp.outputOrder;
-    if (!t.getChangeOutput()) {
-      outputOrder = _.dropRight(outputOrder);
-    }
+    var outputOrder = _.reject(txp.outputOrder, function(order) {
+      return order >= t.outputs.length;
+    });
     $.checkState(t.outputs.length == outputOrder.length);
     t.sortOutputs(function(outputs) {
       return _.map(outputOrder, function(i) {

--- a/lib/api.js
+++ b/lib/api.js
@@ -823,9 +823,13 @@ API.buildTx = function(txp) {
 
   // Shuffle outputs for improved privacy
   if (t.outputs.length > 1) {
-    $.checkState(t.outputs.length == txp.outputOrder.length);
+    var outputOrder = txp.outputOrder;
+    if (!t.getChangeOutput()) {
+      outputOrder = _.dropRight(outputOrder);
+    }
+    $.checkState(t.outputs.length == outputOrder.length);
     t.sortOutputs(function(outputs) {
-      return _.map(txp.outputOrder, function(i) {
+      return _.map(outputOrder, function(i) {
         return outputs[i];
       });
     });

--- a/test/client.js
+++ b/test/client.js
@@ -589,16 +589,21 @@ describe('client API', function() {
         var txp = {
           inputs: utxos,
           type: 'external',
-          outputs: [{
-            "amount": 700,
-            "script": "512103ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff210314a96cd6f5a20826070173fe5b7e9797f21fc8ca4a55bcb2d2bde99f55dd352352ae"
-          }, {
-            "amount": 600,
-            "script": "76a9144d5bd54809f846dc6b1a14cbdd0ac87a3c66f76688ac"
-          }, {
-            "amount": 0,
-            "script": "6a1e43430102fa9213bc243af03857d0f9165e971153586d3915201201201210"
-          }],
+          outputs: [
+            {
+              "toAddress":"18433T2TSgajt9jWhcTBw4GoNREA6LpX3E",
+              "amount":700,
+              "script":"512103ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff210314a96cd6f5a20826070173fe5b7e9797f21fc8ca4a55bcb2d2bde99f55dd352352ae"
+            },
+            {
+              "amount":600,
+              "script":"76a9144d5bd54809f846dc6b1a14cbdd0ac87a3c66f76688ac"
+            },
+            {
+              "amount":0,
+              "script":"6a1e43430102fa9213bc243af03857d0f9165e971153586d3915201201201210"
+            }
+          ],
           changeAddress: {
             address: changeAddress
           },
@@ -623,7 +628,7 @@ describe('client API', function() {
         var changeScript = Bitcore.Script.fromAddress(txp.changeAddress.address).toHex();
         t.outputs[3].script.toHex().should.equal(changeScript);
       });
-      it('should fail if provided output has both toAddress and script', function() {
+      it('should fail if provided output has no either toAddress or script', function() {
         var toAddress = 'msj42CCGruhRsFrGATiUuh25dtxYtnpbTx';
         var changeAddress = 'msj42CCGruhRsFrGATiUuh25dtxYtnpbTx';
 
@@ -636,9 +641,7 @@ describe('client API', function() {
           inputs: utxos,
           type: 'external',
           outputs: [{
-            "toAddress": "18433T2TSgajt9jWhcTBw4GoNREA6LpX3E",
             "amount": 700,
-            "script": "512103ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff210314a96cd6f5a20826070173fe5b7e9797f21fc8ca4a55bcb2d2bde99f55dd352352ae"
           }, {
             "amount": 600,
             "script": "76a9144d5bd54809f846dc6b1a14cbdd0ac87a3c66f76688ac"
@@ -659,8 +662,16 @@ describe('client API', function() {
           var t = Client.buildTx(txp);
         }).should.throw('Output should have either toAddress or script specified');
 
-        delete txp.outputs[0].toAddress;
+        txp.outputs[0].toAddress = "18433T2TSgajt9jWhcTBw4GoNREA6LpX3E";
         var t = Client.buildTx(txp);
+        var bitcoreError = t.getSerializationError({
+          disableIsFullySigned: true,
+        });
+        should.not.exist(bitcoreError);
+        
+        delete txp.outputs[0].toAddress;
+        txp.outputs[0].script = "512103ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff210314a96cd6f5a20826070173fe5b7e9797f21fc8ca4a55bcb2d2bde99f55dd352352ae";
+        t = Client.buildTx(txp);
         var bitcoreError = t.getSerializationError({
           disableIsFullySigned: true,
         });
@@ -2003,6 +2014,7 @@ describe('client API', function() {
         toAddress: toAddress,
       });
       clients[0].sendTxProposal(opts2, function(err, txp) {
+        console.log(err);
         should.not.exist(err);
         var t = Client.buildTx(txp);
         t.toObject().outputs.length.should.equal(opts2.outputs.length);


### PR DESCRIPTION
Size of ``outputOrder`` array always assumes that change output will be
added. This leads to failed assertion in ``buildTx`` when no change output needed.

Duplicates: https://github.com/bitpay/bitcore-wallet-utils/pull/28