### PR TITLE
Increase timespan in the fetching notifications loop

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -99,7 +99,7 @@ API.prototype._fetchLatestNotifications = function(interval, cb) {
   };
 
   if (!self.lastNotificationId) {
-    opts.timeSpan = interval;
+    opts.timeSpan = interval + 1;
   }
 
   self.getNotifications(opts, function(err, notifications) {


### PR DESCRIPTION
There is a rare condition in which the client could miss some notification. 
In the polling cycle it can happen that the client makes the request for the notifications with a delay (i.e. for overload) and losts the notification for the lag. For example if the notification interval is 5 sec but the request happens after 5.5 sec the previous request, the notifications generated in the first 0.5 seconds after the previous request will not be retrieved.

A workaround could be to specify a timespan slightly greater than the polling interval.