### PR TITLE
Pass through validateOutputs option

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -1530,7 +1530,8 @@ API.prototype.createTxProposal = function(opts, cb) {
     excludeUnconfirmedUtxos: !!opts.excludeUnconfirmedUtxos,
     customData: opts.customData,
     inputs: opts.inputs,
-    utxosToExclude: opts.utxosToExclude
+    utxosToExclude: opts.utxosToExclude,
+    validateOutputs: opts.validateOutputs
   };
 
   args.outputs = _.map(opts.outputs, function(o) {


### PR DESCRIPTION
Otherwise there is no way to skip outputs validation [here](https://github.com/bitpay/bitcore-wallet-service/blob/4c9b685e1c9b2319dc1ce42f132768c2f869ba86/lib/server.js#L1855)