### PR TITLE
Allow for mnemonic or xprv only airgapped signing.

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -1829,6 +1829,7 @@ API.prototype.getBalance = function(opts, cb) {
  * @param {Object} opts
  * @param {Boolean} opts.doNotVerify
  * @param {Boolean} opts.forAirGapped
+ * @param {Boolean} opts.doNotEncryptPkr
  * @return {Callback} cb - Return error or array of transactions proposals
  */
 API.prototype.getTxProposals = function(opts, cb) {
@@ -1860,7 +1861,8 @@ API.prototype.getTxProposals = function(opts, cb) {
         if (opts.forAirGapped) {
           result = {
             txps: JSON.parse(JSON.stringify(txps)),
-            encryptedPkr: Utils.encryptMessage(JSON.stringify(self.credentials.publicKeyRing), self.credentials.personalEncryptingKey),
+            encryptedPkr: opts.doNotEncryptPkr ? null : Utils.encryptMessage(JSON.stringify(self.credentials.publicKeyRing), self.credentials.personalEncryptingKey),
+            unencryptedPkr: opts.doNotEncryptPkr ? JSON.stringify(self.credentials.publicKeyRing) : null,
             m: self.credentials.m,
             n: self.credentials.n,
           };
@@ -1980,6 +1982,60 @@ API.prototype.signTxProposalFromAirGapped = function(txp, encryptedPkr, m, n) {
     throw new Error('Fake transaction proposal');
 
   return self._signTxp(txp);
+};
+
+
+/**
+ * Sign transaction proposal from AirGapped
+ *
+ * @param {String} key - A mnemonic phrase or an xprv HD private key
+ * @param {Object} txp
+ * @param {String} unencryptedPkr
+ * @param {Number} m
+ * @param {Number} n
+ * @param {String} network - 'livenet' or 'testnet' (default: 'livenet')
+ * @param {String} passphrase
+ * @param {Number} account - default 0
+ * @param {String} derivationStrategy - default 'BIP44'
+ * @return {Object} txp - Return transaction
+ */
+API.signTxProposalFromAirGapped = function(key, txp, unencryptedPkr, m, n, network, passphrase, account, derivationStrategy) {
+  var self = this;
+
+  var publicKeyRing = JSON.parse(unencryptedPkr);
+
+  if (!_.isArray(publicKeyRing) || publicKeyRing.length != n) {
+    throw new Error('Invalid public key ring');
+  }
+  
+  var newClient = new API({
+    baseUrl: 'https://bws.example.com/bws/api',
+    verbose: false,
+  })
+  
+  if (key.slice(0,4) === 'xprv') {
+    newClient.seedFromExtendedPrivateKey(key, {
+      'account': account,
+      'derivationStrategy': derivationStrategy
+    });
+  } else {
+    newClient.seedFromMnemonic(key, {
+      'network': network,
+      'passphrase': passphrase,
+      'account': account,
+      'derivationStrategy': derivationStrategy
+    })
+  }
+
+  newClient.credentials.m = m;
+  newClient.credentials.n = n;
+  newClient.credentials.addressType = txp.addressType;
+  newClient.credentials.addPublicKeyRing(publicKeyRing);
+
+  if (!Verifier.checkTxProposalSignature(newClient.credentials, txp))
+    throw new Error('Fake transaction proposal');
+
+  return newClient._signTxp(txp);
 };
 
 


### PR DESCRIPTION
Currently to sign air gapped, you need the decryption key for the pubkey ring. Which needs the exported wallet file.

For offline signing, just typing in a mnemonic is best with no need to store the credentials (encrypted or not) on the disk.

In most cases, transit for airgap is secure, and the worry of data management on air gapped machine is much more of a hassle than the worry of leaking public keys. (which, if you have someone attacking your machines, they will find out eventually.)