### PR TITLE
Use more explicit logic in fee level check

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -2352,7 +2352,7 @@ API.prototype.getSendMaxInfo = function(opts, cb) {
   opts = opts || {};
 
   if (opts.feeLevel) args.push('feeLevel=' + opts.feeLevel);
-  if (opts.feePerKb) args.push('feePerKb=' + opts.feePerKb);
+  if (opts.feePerKb != null) args.push('feePerKb=' + opts.feePerKb);
   if (opts.excludeUnconfirmedUtxos) args.push('excludeUnconfirmedUtxos=1');
   if (opts.returnInputs) args.push('returnInputs=1');
 


### PR DESCRIPTION
Bitcore-Wallet-Service allows for a minimum fee of `0`, however if this is the case it will currently cause Copay errors. These problems are caused by the `opts.feePerKb` check that returns false on a case of `0`.

This PR only solves half of the problem as there are similar checks in Copay itself, which I have also created a [pull request](https://github.com/bitpay/copay/pull/4720) for.
