### PR TITLE
Pass paypro amount verifier check if requested amount is zero

### DIFF
--- a/lib/verifier.js
+++ b/lib/verifier.js
@@ -171,10 +171,10 @@ Verifier.checkPaypro = function(txp, payproOpts) {
 
   if (parseInt(txp.version) >= 3) {
     toAddress = txp.outputs[0].toAddress;
-    amount = txp.amount;
+    amount = payproOpts.amount ? txp.amount : 0;
   } else {
     toAddress = txp.toAddress;
-    amount = txp.amount;
+    amount = payproOpts.amount ? txp.amount : 0;
   }
 
   return (toAddress == payproOpts.toAddress && amount == payproOpts.amount);


### PR DESCRIPTION
Required by bitpay/copay#4957 in order to correctly skip verifying amount if paypro request specifies so.