### PR TITLE
better error message parsing

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -261,7 +261,7 @@ API._parseError = function(body) {
       ret = new Error(body.code + ': ' + body.message);
     }
   } else {
-    ret = new Error(body.error || body);
+    ret = new Error(body.error || JSON.stringify(body));
   }
   log.error(ret);
   return ret;


### PR DESCRIPTION
Handles when the HTTP error message comes in a field other that `.error` (like .message).