### PR TITLE
Updates feeLevel API request to v2

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -1247,7 +1247,7 @@ API.prototype.getFeeLevels = function(network, cb) {
 
   $.checkArgument(network || _.contains(['livenet', 'testnet'], network));
 
-  self._doGetRequest('/v1/feelevels/?network=' + (network || 'livenet'), function(err, result) {
+  self._doGetRequest('/v2/feelevels/?network=' + (network || 'livenet'), function(err, result) {
     if (err) return cb(err);
     return cb(err, result);
   });


### PR DESCRIPTION
Since it seems you have updated to v2 endpoints on a variety of methods the `bitcore-wallet-client` uses, it would be great to get these updated.