### PR TITLE
Update to the new lodash aliases

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -218,7 +218,7 @@ API.prototype._processTxps = function(txps) {
       output.encryptedMessage = output.message;
       output.message = API._decryptMessage(output.message, encryptingKey) || null;
     });
-    txp.hasUnconfirmedInputs = _.any(txp.inputs, function(input) {
+    txp.hasUnconfirmedInputs = _.some(txp.inputs, function(input) {
       return input.confirmations == 0;
     });
     self._processTxNotes(txp.note);
@@ -1193,7 +1193,7 @@ API.prototype.decryptPrivateKey = function(password) {
 API.prototype.getFeeLevels = function(network, cb) {
   var self = this;
 
-  $.checkArgument(network || _.contains(['livenet', 'testnet'], network));
+  $.checkArgument(network || _.includes(['livenet', 'testnet'], network));
 
   self._doGetRequest('/v1/feelevels/?network=' + (network || 'livenet'), function(err, result) {
     if (err) return cb(err);
@@ -1242,7 +1242,7 @@ API.prototype.createWallet = function(walletName, copayerName, m, n, opts, cb) {
   opts = opts || {};
 
   var network = opts.network || 'livenet';
-  if (!_.contains(['testnet', 'livenet'], network)) return cb(new Error('Invalid network'));
+  if (!_.includes(['testnet', 'livenet'], network)) return cb(new Error('Invalid network'));
 
   if (!self.credentials) {
     log.info('Generating new keys');
@@ -1765,7 +1765,7 @@ API.prototype.getMainAddresses = function(opts, cb) {
     if (err) return cb(err);
 
     if (!opts.doNotVerify) {
-      var fake = _.any(addresses, function(address) {
+      var fake = _.some(addresses, function(address) {
         return !Verifier.checkAddress(self.credentials, address);
       });
       if (fake)

--- a/lib/common/utils.js
+++ b/lib/common/utils.js
@@ -98,7 +98,7 @@ Utils.getProposalHash = function(proposalHeader) {
 };
 
 Utils.deriveAddress = function(scriptType, publicKeyRing, path, m, network) {
-  $.checkArgument(_.contains(_.values(Constants.SCRIPT_TYPES), scriptType));
+  $.checkArgument(_.includes(_.values(Constants.SCRIPT_TYPES), scriptType));
 
   var publicKeys = _.map(publicKeyRing, function(item) {
     var xpub = new Bitcore.HDPublicKey(item.xPubKey);
@@ -140,7 +140,7 @@ Utils.verifyRequestPubKey = function(requestPubKey, signature, xPubKey) {
 
 Utils.formatAmount = function(satoshis, unit, opts) {
   $.shouldBeNumber(satoshis);
-  $.checkArgument(_.contains(_.keys(Constants.UNITS), unit));
+  $.checkArgument(_.includes(_.keys(Constants.UNITS), unit));
 
   function clipDecimals(number, decimals) {
     var x = number.toString().split('.');
@@ -174,7 +174,7 @@ Utils.formatAmount = function(satoshis, unit, opts) {
 Utils.buildTx = function(txp) {
   var t = new Bitcore.Transaction();
 
-  $.checkState(_.contains(_.values(Constants.SCRIPT_TYPES), txp.addressType));
+  $.checkState(_.includes(_.values(Constants.SCRIPT_TYPES), txp.addressType));
 
   switch (txp.addressType) {
     case Constants.SCRIPT_TYPES.P2SH:

--- a/lib/credentials.js
+++ b/lib/credentials.js
@@ -45,7 +45,7 @@ function Credentials() {
 };
 
 function _checkNetwork(network) {
-  if (!_.contains(['livenet', 'testnet'], network)) throw new Error('Invalid network');
+  if (!_.includes(['livenet', 'testnet'], network)) throw new Error('Invalid network');
 };
 
 Credentials.create = function(network) {
@@ -93,7 +93,7 @@ Credentials.createWithMnemonic = function(network, passphrase, language, account
 
 Credentials.fromExtendedPrivateKey = function(xPrivKey, account, derivationStrategy, opts) {
   $.shouldBeNumber(account);
-  $.checkArgument(_.contains(_.values(Constants.DERIVATION_STRATEGIES), derivationStrategy));
+  $.checkArgument(_.includes(_.values(Constants.DERIVATION_STRATEGIES), derivationStrategy));
 
   opts = opts || {};
 
@@ -109,7 +109,7 @@ Credentials.fromExtendedPrivateKey = function(xPrivKey, account, derivationStrat
 Credentials.fromMnemonic = function(network, words, passphrase, account, derivationStrategy, opts) {
   _checkNetwork(network);
   $.shouldBeNumber(account);
-  $.checkArgument(_.contains(_.values(Constants.DERIVATION_STRATEGIES), derivationStrategy));
+  $.checkArgument(_.includes(_.values(Constants.DERIVATION_STRATEGIES), derivationStrategy));
 
   opts = opts || {};
 
@@ -138,7 +138,7 @@ Credentials.fromMnemonic = function(network, words, passphrase, account, derivat
 Credentials.fromExtendedPublicKey = function(xPubKey, source, entropySourceHex, account, derivationStrategy, opts) {
   $.checkArgument(entropySourceHex);
   $.shouldBeNumber(account);
-  $.checkArgument(_.contains(_.values(Constants.DERIVATION_STRATEGIES), derivationStrategy));
+  $.checkArgument(_.includes(_.values(Constants.DERIVATION_STRATEGIES), derivationStrategy));
 
   opts = opts || {};
 

--- a/lib/verifier.js
+++ b/lib/verifier.js
@@ -72,7 +72,7 @@ Verifier.checkCopayers = function(credentials, copayers) {
 
   if (error) return false;
 
-  if (!_.contains(_.pluck(copayers, 'xPubKey'), credentials.xPubKey)) {
+  if (!_.includes(_.pluck(copayers, 'xPubKey'), credentials.xPubKey)) {
     log.error('Server response does not contains our public keys')
     return false;
   }

--- a/test/client.js
+++ b/test/client.js
@@ -185,7 +185,7 @@ var blockchainExplorerMock = {};
 
 blockchainExplorerMock.getUtxos = function(addresses, cb) {
   var selected = _.filter(blockchainExplorerMock.utxos, function(utxo) {
-    return _.contains(addresses, utxo.address);
+    return _.includes(addresses, utxo.address);
   });
   return cb(null, selected);
 };
@@ -232,7 +232,7 @@ blockchainExplorerMock.getTransactions = function(addresses, from, to, cb) {
 
 blockchainExplorerMock.getAddressActivity = function(address, cb) {
   var activeAddresses = _.pluck(blockchainExplorerMock.utxos || [], 'address');
-  return cb(null, _.contains(activeAddresses, address));
+  return cb(null, _.includes(activeAddresses, address));
 };
 
 blockchainExplorerMock.setFeeLevels = function(levels) {


### PR DESCRIPTION
These alias are used in lodash 3.x and 4.x, and needed for future migration to 4.x.

The functionality is preserved.

I made this change because I'm trying to implement bwc in Angular 2 with TypeScript, and for some reason the typings for lodash 3.10.1 are not fully described.