### PR TITLE
Add hwInfo to credentials

### DIFF
--- a/lib/credentials.js
+++ b/lib/credentials.js
@@ -37,6 +37,7 @@ var FIELDS = [
   'account',
   'compliantDerivation',
   'addressType',
+  'hwInfo',
 ];
 
 function Credentials() {


### PR DESCRIPTION
Allows for storing hardware wallet information with wallet credentials.  Support for TEE hardware (e.g., stores TEE hardware wallet id).