### PR TITLE
Fix wrong type in function documentation

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -419,7 +419,7 @@ API.prototype.seedFromExtendedPrivateKey = function(xPrivKey, opts) {
  * Seed from Mnemonics (language autodetected)
  * Can throw an error if mnemonic is invalid
  *
- * @param {String} BIP39 words
+ * @param {Array} BIP39 words
  * @param {Object} opts
  * @param {String} opts.coin - default 'btc'
  * @param {String} opts.network - default 'livenet'


### PR DESCRIPTION
Tripped over this when trying to use the wrong way.